### PR TITLE
Update OpenPGP.js to v6, and add support for profiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Code Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, v6]
   pull_request:
     branches: [main]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-1",
       "license": "ISC",
       "dependencies": {
-        "openpgp": "npm:openpgp@~6.0.0-beta.3.patch.1",
+        "openpgp": "^6.0.0",
         "yargs": "^14.2.0"
       },
       "devDependencies": {
@@ -1062,10 +1062,9 @@
       }
     },
     "node_modules/openpgp": {
-      "version": "6.0.0-beta.3.patch.1",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.0.0-beta.3.patch.1.tgz",
-      "integrity": "sha512-sD5Ornw703D6gjQNVoJdFs/GM0n74STsxUuQkctlGDzBCuZ0QZXgyGtnvxlaagnmI9fy6UoCzmTw7KV5NWYjaw==",
-      "license": "LGPL-3.0+",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.0.0.tgz",
+      "integrity": "sha512-8YMuhOV6bP8+J4bCHltvRwol1sBJhxAcJXvwEKpcK65lKpQ0VUbymQR/EuGrzxYnatNSyMyrMgip4j/F0vhZvg==",
       "engines": {
         "node": ">= 18.0.0"
       }
@@ -2325,9 +2324,9 @@
       }
     },
     "openpgp": {
-      "version": "6.0.0-beta.3.patch.1",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.0.0-beta.3.patch.1.tgz",
-      "integrity": "sha512-sD5Ornw703D6gjQNVoJdFs/GM0n74STsxUuQkctlGDzBCuZ0QZXgyGtnvxlaagnmI9fy6UoCzmTw7KV5NWYjaw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.0.0.tgz",
+      "integrity": "sha512-8YMuhOV6bP8+J4bCHltvRwol1sBJhxAcJXvwEKpcK65lKpQ0VUbymQR/EuGrzxYnatNSyMyrMgip4j/F0vhZvg=="
     },
     "optionator": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "openpgp": "npm:openpgp@~6.0.0-beta.3.patch.1",
+    "openpgp": "^6.0.0",
     "yargs": "^14.2.0"
   },
   "devDependencies": {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -8,18 +8,18 @@ const CUSTOM_PROFILES = JSON.parse(process.env.OPENPGPJS_CUSTOM_PROFILES || '{}'
 const BUILTIN_PROFILES = {
   encrypt: {
     'default': DEFAULT_PROFILE,
-    'crypto-refresh': {
+    'rfc9580': {
       description: 'use AEAD for password-protected messages',
       options: { config: { aeadProtect: true } }
     }
   },
   'generate-key': {
     'default': DEFAULT_PROFILE,
-    'rfc4880bis': {
+    'rfc4880': {
       description: 'generate RSA keys',
       options: { type: 'rsa' }
     },
-    'crypto-refresh': {
+    'rfc9580': {
       description: 'generate v6 keys with SEIPDv2 feature flag',
       options: { config: { v6Keys: true, aeadProtect: true } }
     }


### PR DESCRIPTION
Pending the v6 release, this branch is primarily used for openpgpjs CI testing.

NB: the implemented profiles only work with OpenPGP.js v6, and will error or misbehave in previous versions. For this reason, the env variable `DISABLE_PROFILES` has also been added to manually turn off profiles; the flag should be set to `'true'` if older versions of OpenPGP.js are used.

TODO:
- [ ] Point to openpgpjs v6 release