### PR TITLE
[v6] Make finding the signing key more robust

### DIFF
--- a/src/commands/inlineVerify.js
+++ b/src/commands/inlineVerify.js
@@ -44,7 +44,7 @@ const inlineVerify = async (certfiles, verificationsOut) => {
         const signature = await s.signature;
         const timestamp = utils.format_date(signature.packets[0].created);
         for (const cert of verificationKeys) {
-          const signingKey = await cert.getSigningKey(s.keyID, null).catch(() => null);
+          const [signingKey] = await cert.getKeys(s.keyID);
           if (signingKey) {
             verifications +=
               timestamp

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -42,7 +42,7 @@ const verify = async (signature, certfiles) => {
         const signature = await s.signature;
         const timestamp = utils.format_date(signature.packets[0].created);
         for (const cert of certs) {
-          const signingKey = await cert.getSigningKey(s.keyID, null).catch(() => null);
+          const [signingKey] = await cert.getKeys(s.keyID);
           if (signingKey) {
             console.log(timestamp
                         + ' ' + signingKey.getFingerprint().toUpperCase()


### PR DESCRIPTION
More reliably find the signing key that OpenPGP.js used to verify a given signature.