### PR TITLE
Improve profiles

### DIFF
--- a/src/commands/listProfiles.js
+++ b/src/commands/listProfiles.js
@@ -3,9 +3,6 @@ const { UNSUPPORTED_PROFILE } = require('../errorCodes');
 const PROFILES = require('../profiles');
 
 const listProfiles = (subcommand) => {
-  if (process.env.DISABLE_PROFILES?.toLowerCase() === 'true') {
-    return;
-  }
   const supportedProfiles = Object.entries(PROFILES[subcommand] || {});
   if (!supportedProfiles.length) {
     console.error('no supported profiles');

--- a/src/commands/listProfiles.js
+++ b/src/commands/listProfiles.js
@@ -12,7 +12,16 @@ const listProfiles = (subcommand) => {
     return process.exit(UNSUPPORTED_PROFILE);
   }
 
-  supportedProfiles.forEach(([name, { description }]) => process.stdout.write(`${name}: ${description}\n`));
+  supportedProfiles.forEach(([name, { description, isAlias, aliases }]) => {
+    if (!isAlias) {
+      const aliasStr = aliases
+        ? (aliases.length > 1
+          ? ` (aliases: ${aliases.join(', ')})`
+          : ` (alias: ${aliases[0]})`)
+        : '';
+      process.stdout.write(`${name}: ${description}${aliasStr}\n`);
+    }
+  });
 };
 
 module.exports = listProfiles;

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,7 +55,7 @@ const format_date = (d) => {
 const getProfileOptions = (subcommand, profileName = 'default') => {
   const profile = PROFILES[subcommand]?.[profileName];
   if (!profile) {
-    console.error('no supported profiles');
+    console.error('unsupported profile');
     return process.exit(UNSUPPORTED_PROFILE);
   }
 

--- a/test/run
+++ b/test/run
@@ -130,8 +130,18 @@ echo 'Test inline signing and verifying with generated key' |
 echo 'Test profiles'
 ./sopenpgpjs list-profiles generate-key > /dev/null
 ./sopenpgpjs list-profiles encrypt > /dev/null
-./sopenpgpjs  generate-key --profile crypto-refresh test@test > /dev/null
-echo 'plaintext' | ./sopenpgpjs encrypt --profile crypto-refresh --with-password test/password.txt > /dev/null
+./sopenpgpjs generate-key --profile default test@test > /dev/null
+./sopenpgpjs generate-key --profile security test@test > /dev/null
+./sopenpgpjs generate-key --profile performance test@test > /dev/null
+./sopenpgpjs generate-key --profile compatibility test@test > /dev/null
+./sopenpgpjs generate-key --profile rfc4880 test@test > /dev/null
+./sopenpgpjs generate-key --profile rfc9580 test@test > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile default --with-password test/password.txt > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile security --with-password test/password.txt > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile performance --with-password test/password.txt > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile compatibility --with-password test/password.txt > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile rfc4880 --with-password test/password.txt > /dev/null
+echo 'plaintext' | ./sopenpgpjs encrypt --profile rfc9580 --with-password test/password.txt > /dev/null
 OPENPGPJS_CUSTOM_PROFILES='{ "generate-key": { "post-quantum": {
     "description": "generate post-quantum v6 keys (relying on ML-DSA + ML-KEM)",
     "options": { "type": "pqc", "config": { "v6Keys": true } }


### PR DESCRIPTION
- Use more understandable profile names ("compatibility", "performance" and "security"), as per https://gitlab.com/dkg/openpgp-stateless-cli/-/merge_requests/37 (with the current names as aliases)
- Add a profile for Curve448 key generation (under the name "security")
- Remove the `DISABLE_PROFILES` env variable
  It's no longer needed since we now always use OpenPGP.js v6 on the main branch. For testing OpenPGP.js v5, the openpgpjs-v5 branch can be used.
- Improve the error message when an unsupported profile is requested